### PR TITLE
chore: test against node v20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [12, 14, 16, 18, 20]
         keycloak:
           - "5.0.0"
           - "6.0.1"


### PR DESCRIPTION
Update the github workflow to test against node v20